### PR TITLE
fix: Errorboundary의 탈출 로직들이 동작하지 않던 문제 

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,24 @@
 'use client';
 
-import { ErrorFallback } from '@/frontend/components/common';
+import { ErrorSection } from '@/frontend/components/common';
+import { useRouter } from 'next/navigation';
 
-export default ErrorFallback;
+// Next가 error.tsx에 전달하는 props 타입
+type Props = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function Error({ error, reset }: Props) {
+  const router = useRouter();
+
+  const goChatPage = () => router.push('/chat');
+
+  return (
+    <ErrorSection
+      errorMessage={error?.message || '알 수 없는 에러가 발생했습니다'}
+      handleReload={reset}
+      handleGoOtherPage={goChatPage}
+    />
+  );
+}

--- a/src/frontend/components/common/ErrorFallback.tsx
+++ b/src/frontend/components/common/ErrorFallback.tsx
@@ -2,15 +2,12 @@
 
 import { ErrorSection } from '@/frontend/components/common';
 import { useRouter } from 'next/navigation';
-import { FallbackProps } from 'react-error-boundary';
+import type { FallbackProps } from 'react-error-boundary';
 
 const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   const router = useRouter();
 
-  const goChatPage = () => {
-    resetErrorBoundary();
-    router.push('/chat');
-  };
+  const goChatPage = () => router.push('/chat');
 
   return (
     <ErrorSection


### PR DESCRIPTION
> 1. `error.tsx` 파일을 Next에서 요구하는 형식으로 변경
> 2. 불필요한 `reset` 호출 제거

<br>

## 문제 상황
### resetErrorBoundary is not a function
- 프로젝트 내에서 같은 Error Fallback을 공유하기 위해 `error.tsx`에서 `ErrorFallback` 컴포넌트를 가져와 그대로 사용했음.
```tsx
'use client';

import { ErrorFallback } from '@/frontend/components/common';
export default ErrorFallback;
```
  - `ErrorFallback`의 props는 `{ error: Error, resetErrorBoundary: () => void }`였음. (react-error-boundary의 `FallbackProps` 타입)
- 하지만 Next는 렌더링 에러가 발생하면 자동으로 `error.tsx`를 실행함(에러 바운더리처럼 작동). 즉 에러가 여기서 잡힘. 
- 이때 `error.tsx`가 받는 타입은 `{ error: Error, reset: () => void }`라 하위 컴포넌트에서 `resetErrorBoundary`를 호출하면 당연히 없는 함수라 undefined가 뜸.

#### 근데 layout에서 직접 Errorboundary로 감싸줬는데?
```tsx
 <QueryErrorResetBoundary>
      {(
        { reset }, 
      ) => (
        <ErrorBoundary
          FallbackComponent={ErrorFallback}
          onReset={reset} 
        >
          {children}
        </ErrorBoundary>
      )}
    </QueryErrorResetBoundary>
```
ㄴ 이걸 layout에서 사용하고 있었다.

`error.tsx`가 에러 바운더리처럼 작동한다고 했지만 나는 `layout.tsx`에서 직접 에러 바운더리를 사용했는데, 이건 왜 안 잡히지? 원래 에러 바운더리는 렌더링 도중의 에러도 잡아주지 않나? 라고 생각했었다.
근데 layout이 더 높은 계층이라, 에러 throw 지점과 더 가까운 `error.tsx`가 잡고 끝나는 거였다!!
<img width="876" height="659" alt="image" src="https://github.com/user-attachments/assets/1e535505-c649-4024-9225-f14638639004" />
ㄴ [공식문서 ](https://nextjs.org/docs/app/getting-started/project-structure#organizing-your-project)피셜 😅

#### 그럼 수제 Errorboundary는 필요 없나?
물론 (페이지 전역) `error.tsx`는 페이지 전체를 덮는 fallback이니까, 그보다 작은 범위에서 에러를 다루려면 수제 바운더리를 써야 한다. 
하지만 나는 fallback을 무조건 화면 전체를 덮는 용도로 쓰고 있었기에 이 장점은 별로 중요하지 않았다.
수제 바운더리의 또다른 장점은 `QueryErrorResetBoundary`의 `reset` 함수를 받아 쓸 수 있다는 점인 것 같다. `error.tsx`가 처리하면 reset 함수는 무조건 페이지 리로드로 들어가는데, query reset을 받아오면 에러가 발생한 쿼리만 리셋하는 거라 때에 따라 더 경제적으로 에러를 처리할 수 있다. 섬세한 부분별 에러 처리가 필요할 때 좋을 것 같다.

- TODO) 지금은 fallback을 모든 페이지를 덮도록 띄우지만 나중에는 에러 난 리스트만 덮도록 변경해야겠다. 

#### 반대로 error.tsx가 없어도 되는지?
그럼 반대로 `error.tsx` 없애고 단일 에러바운더리만 써도 되는 거 아냐?라고 생각했다.
근데 이건 다분히 CSR적인 생각이었다. SSR 담당인 서버 입장에서는 에러바운더리가 애당초 클라이언트 컴포넌트이기 때문에 에러가 나면 별도로 처리 및 안내할 수가 없다. (내가 열심히 만든 화면 대신 next 기본 에러 fallback이 뜨는 등)
따라서 Next가 서버에게 알려주기로 약속한 `error.tsx`를 써야 SSR 환경에서도 에러를 아름답게 처리할 수 있는 거였다.

--- 

### 페이지 이동 시 reset 호출
- router로 다른 페이지로 이동하기 전, 에러가 난 캐시 상태를 지워야 한다고 생각해서 `reset`함수를 호출함.
  - staleTime이 지나지 않은 상황에서 에러 상태를 그대로 두면 나중에 다시 돌아왔을 때 계속 에러를 보여줄 거라고 생각했음
- 그러나 (이유는 정확히 알 수 없었지만) 서버는 route가 일어난 것으로 생각하고 그 페이지를 컴파일해오는데 (error 상태가 계속 true라 그 맥락 안에서 라우트 이동 보내도 무시당하는 듯? 아니면 데드락...?) 브라우저에서는 계속 fallback만 띄워줬고, 어느 순간부터는 렌더링이 엉켰는지 화면이 다운됐음.
  - 라우터 대신 `window.href`로 이동해도 Fallback에서 빠져나올 수는 없었음
- 그래서 일단 리셋 함수 빼고 그냥 페이지 이동만 시도해봄. (얘도 위의 이슈로 undefined가 떴었기에 잘 돌아가는지 테스트 못해봤었음)

#### 캐시 테스트
테스트한 순서는 이랬다.
- 페이지 B에서 에러 띄움(staleTime 충분히 줌) 
- -> fallback을 이용해 페이지 A로 이동(next 라우터 사용) 
- -> 에러 트리거 로직을 지우고 다시 페이지 B 입장 

그럼 캐시는 이렇게 변했다.
- **error** -> inactive (fallback이 대신 렌더돼서 이 데이터를 쓰는 컴포넌트가 없어짐 - 근데 실상 error & inactive임)
- inactive (다른 페이지로 이동했으므로)
- active -> fetching -> **fresh**

예상과 다르게 새 데이터를 잘 받아왔다.

> 근데 난 명시적으로 invalidate를 안 했는데?!

#### retryOnMount
비결은 잊고 살았던 `retryOnMount` 때문이었다. (기본값 true)
<img width="864" height="121" alt="image" src="https://github.com/user-attachments/assets/2f17ae36-9a58-4065-b415-87aef1fea03e" />

얘 덕분에 컴포넌트가 새로 마운트될 때(페이지 B 재호출) 에러였던 쿼리에 리트라이가 자동으로 일어나서 멀쩡한 데이터를 가져올 수 있다. 

#### cf. status
<img width="569" height="38" alt="image" src="https://github.com/user-attachments/assets/2a39529b-5483-4f86-8b52-514df89efd28" />

처음엔 여기서 inactive가 켜지고 다른 플래그는 0으로 뜨길래 inactive라는 상태가 독자적으로 있는 건가? 싶었으나
<img width="456" height="359" alt="image" src="https://github.com/user-attachments/assets/8bbf7481-1ff5-457a-90a6-35db0c7ad1e3" />
쿼리 데이터를 까보면 상태가 버젓이 error로 되어 있다. 그래서 찾아보니 active와 inactive는 다른 상태를 덮어쓰는 애가 아니라 공존하는 것들이었다!

## 느낀점
역시 답은 공식문서구나~~~
근데 막상 개발할 때는 진짜 아무것도 모르는 게 아닌 이상 에러가 나고 나서야 찾아보게 되는 것 같다 🤣 
슬슬 공식문서 정독할 때가 온 것 같다.