### PR TITLE
fix: 에러 바운더리의 props 타입 에러

### DIFF
--- a/src/frontend/providers/QueryErrorProvider.tsx
+++ b/src/frontend/providers/QueryErrorProvider.tsx
@@ -5,15 +5,25 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { type ReactNode } from 'react';
 import ErrorFallback from '@/app/error';
 
-type Props = {
+type QueryErrorProviderProps = {
   children: ReactNode;
 };
 
-const QueryErrorProvider = ({ children }: Props) => {
+const QueryErrorProvider = ({ children }: QueryErrorProviderProps) => {
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary FallbackComponent={ErrorFallback} onReset={reset}>
+        <ErrorBoundary
+          fallbackRender={({ error, resetErrorBoundary }) => (
+            <ErrorFallback
+              error={error}
+              reset={() => {
+                reset(); // TanStack Query 캐시 리셋
+                resetErrorBoundary(); // ErrorBoundary UI 리셋
+              }}
+            />
+          )}
+        >
           {children}
         </ErrorBoundary>
       )}


### PR DESCRIPTION
## 문제
라이브러리에서 요구하는 props 이름과 내가 전달해준 이름이 달라서 타입 에러가 발생했다.

### 기존 코드
```tsx
const QueryErrorProvider = ({ children }: Props) => {
  return (
    <QueryErrorResetBoundary>
      {({ reset }) => (
        <ErrorBoundary FallbackComponent={ErrorFallback} onReset={reset}>
          {children}
        </ErrorBoundary>
      )}
    </QueryErrorResetBoundary>
  );
};

export default QueryErrorProvider;
```

- 에러 로그
```text
Type '({ error, reset }: Props) => Element' is not assignable to type 'ComponentType<FallbackProps> | undefined'.
  Type '({ error, reset }: Props) => Element' is not assignable to type 'FunctionComponent<FallbackProps>'.
    Types of parameters '__0' and 'props' are incompatible.
      Property 'reset' is missing in type 'FallbackProps' but required in type 'Props'.ts(2322)
error.tsx(9, 3): 'reset' is declared here.
types.d.ts(30, 5): The expected type comes from property 'FallbackComponent' which is declared here on type 'IntrinsicAttributes & (IntrinsicClassAttributes<ErrorBoundary> & Readonly<ErrorBoundaryProps>)'
```

### 해석
- `FallbackComponent` 컴포넌트는 `FallbackProps` 타입을 기대하는데 내가 넘긴 컴포넌트는 저 타입을 만족하지 않음.
  - `FallbackProps`에는 `reset`이 없는데 나는 저 컴포넌트에서 `reset` prop을 빼서 사용하려고 함 -> 에러!

## 해결 방법
- 에러바운더리 라이브러리가 제공하는 함수명은 `resetErrorBoundary`니까 라이브러리에서 함수를 받아올 때는 이 이름으로 정직하게 명시
- 하지만 내 Fallback 컴포넌트의 리셋 함수명을 `resetErrorBoundary`로 명시한다면?
  - 내 Fallback 컴포넌트의 라이브러리 종속성이 올라감
  - 쿼리 리셋 함수도 같이 받아야 하는데 걔는 이름이 `reset`이라 나중에 봤을 때 `왜 reset도 있고 resetErrorBoundary도 있지?` 처럼 의미 파악이 직관적이지 않음
  - `reset` 함수 하나로 쿼리 캐시 리셋 + 에러 바운더리 상태 리셋을 묶어서 해 주는 것이 종속 방지나 의미 파악 면에서 낫다고 생각했다.
- => Render Prop 방식으로 `ErrorFallback`을 렌더하며 함수 이름을 중개해줌

```tsx
 <QueryErrorResetBoundary>
      {({ reset }) => (
        <ErrorBoundary
          fallbackRender={({ error, resetErrorBoundary }) => ( // resetErrorBoundary로 받아옴
            <ErrorFallback
              error={error}
              reset={() => { // Fallback 컴포넌트에는 예전처럼 reset prop만 열어둠
                // 두 리셋 함수를 함께 묶어 실행
                reset(); // TanStack Query 캐시 리셋
                resetErrorBoundary(); // ErrorBoundary UI 리셋
              }}
            />
          )}
        >
          {children}
        </ErrorBoundary>
      )}
    </QueryErrorResetBoundary>
```

## 교훈
### 선언적 & 명시적인 게 디버깅도 편하다
- 기존의 `FallbackComponent` 방식은 라이브러리가 내부적으로 props를 주입해줌 -> 어떤 타입이 들어가는지 한번 더 뒤적거려야 함
- 반면 `fallbackRender`는 개발자가 직접 데이터를 주입하므로 명시적

### 라이브러리와 내 코드의 디커플링
- 이건 원래 하던 방식! 특정 라이브러리에 종속된 네이밍은 되도록 피하고 범용적으로 짓기
- 만약 타입 불일치가 일어난다면 이렇게 중간에서 이름을 중재해주면 좋음
